### PR TITLE
fix: SwapchainD3D12: fence signal/wait implementation

### DIFF
--- a/Inc/Buma3D.h
+++ b/Inc/Buma3D.h
@@ -4842,7 +4842,7 @@ public:
     /**
      * @brief パイプラインキャッシュを取得します。 
      * @param [out] _dst キャッシュされたパイプラインのデータを保持するblobです。 取得された場合、参照カウントが増加することに注意してください。
-     * @return 成功した場合BMRESULT_SUCCEEDが帰ります。
+     * @return 成功した場合BMRESULT_SUCCEEDが返ります。
     */
     virtual BMRESULT
         B3D_APIENTRY GetCachedBlob(

--- a/Source/API/D3D12/FenceD3D12.h
+++ b/Source/API/D3D12/FenceD3D12.h
@@ -67,6 +67,20 @@ public:
     BMRESULT
         B3D_APIENTRY SubmitSignalToCpu(ID3D12CommandQueue* _queue);
 
+    /**
+     * @brief 引数のシグナルフェンスにスワップチェインフェンスとその時のフェンス値を渡します。
+     * @param _src ペイロードとして扱うスワップチェインフェンスです。
+     * @param _wait_value ペイロードとして扱う_srcで待機するフェンス値です。
+     * @return FENCE_TYPE_TIMELINEの場合、BMRESULT_FAILED以下を返します。
+     * @remark SwapChainD3D12::AcquireNextBufferも参照してください。
+    */
+    BMRESULT
+        B3D_APIENTRY SwapPayload(FenceD3D12* _src/*from swapchain*/, uint64_t _wait_value/*from swapchain*/);
+
+private:
+    struct IImpl;
+    IImpl* CreateImplForSwapChain();
+
 private:
     std::atomic_uint32_t                    ref_count;
     util::UniquePtr<util::NameableObjStr>   name;
@@ -78,7 +92,10 @@ private:
     class BinaryGpuToGpuImpl;
     class BinaryGpuToCpuImpl;
     class TimelineImpl;
+    class BinaryGpuToGpuImplForSwapChain;
+    class BinaryGpuToCpuImplForSwapChain;
     IImpl* impl;
+    IImpl* impl_swapchain;
 
 };
 

--- a/Source/API/D3D12/SwapChainD3D12.h
+++ b/Source/API/D3D12/SwapChainD3D12.h
@@ -73,32 +73,6 @@ private:
         util::DyArray<RECT>     dirty_rects;
     };
 
-    struct FENCES_DATA
-    {
-        ~FENCES_DATA()
-        {
-            for (auto& i : present_fences)
-                hlp::SafeRelease(i);
-            present_fences            = {};
-            present_fences_head       = {};
-            fence_submit              = {};
-            dummy_fence_value         = {};
-            present_fence_values      = {};
-            present_fence_values_head = {};
-        }
-        void SetForSignal(uint32_t _current_buffer_index);
-        void SetForWait(uint32_t _current_buffer_index);
-        BMRESULT ResizeFences(DeviceD3D12* _device, uint32_t _buffer_count);
-        util::DyArray<BMRESULT>     fence_results;
-        BMRESULT*                   fence_results_head;
-        util::DyArray<FenceD3D12*>  present_fences;
-        FenceD3D12**                present_fences_head;
-        FENCE_SUBMISSION            fence_submit;
-        uint64_t                    dummy_fence_value;
-        util::DyArray<uint64_t>     present_fence_values;
-        uint64_t*                   present_fence_values_head;
-    };
-
     struct DESC_DATA
     {
         bool is_shared_from_typeless_compatible_formats;
@@ -120,7 +94,7 @@ private:
     IDXGISwapChain4*                        swapchain;
     HANDLE                                  prev_present_completion_event;
     PRESENT_INFO                            present_info;
-    FENCES_DATA                             fences_data;
+    DeviceD3D12::SWAPCHAIN_FENCES_DATA*     fences_data;
     bool                                    is_acquired;
 
 };


### PR DESCRIPTION
FenceD3D12::SwapPayload の追加。 これにより、スワップチェインフェンスをSwapChainD3D12::AcquireNextBuffer に渡された、任意のFenceD3D12オブジェクトで待機操作を行うことができます。